### PR TITLE
fix: upgrade golangci-lint to v2 and remove deprecated build tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         go-version: stable
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v8
+      uses: golangci/golangci-lint-action@v9
       with:
         version: latest
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         args: ['--fix=lf']
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.4.0
+    rev: v2.8.0
     hooks:
       - id: golangci-lint
 

--- a/magefile.go
+++ b/magefile.go
@@ -1,5 +1,4 @@
 //go:build mage
-// +build mage
 
 package main
 


### PR DESCRIPTION
- golangci-lint-action on ci.yml: v8 -> v9
- golangci-lint (pre-commit): v2.4.0 -> v2.8.0
- Remove deprecated // +build mage directive